### PR TITLE
dask bugfix

### DIFF
--- a/arboreto/core.py
+++ b/arboreto/core.py
@@ -446,8 +446,7 @@ def create_graph(expression_matrix,
                 delayed_link_dfs.append(delayed_link_df)
 
     # gather the DataFrames into one distributed DataFrame
-    all_links_df = from_delayed(delayed_link_dfs, meta=_GRN_SCHEMA)
-    all_meta_df = from_delayed(delayed_meta_dfs, meta=_META_SCHEMA)
+    all_links_df = from_delayed(delayed_link_dfs, meta=_GRN_SCHEMA)        
 
     # optionally limit the number of resulting regulatory links, descending by top importance
     if limit:
@@ -460,6 +459,7 @@ def create_graph(expression_matrix,
     n_parts = len(client.ncores()) * repartition_multiplier
 
     if include_meta:
+        all_meta_df = from_delayed(delayed_meta_dfs, meta=_META_SCHEMA)
         return maybe_limited_links_df.repartition(npartitions=n_parts), \
                all_meta_df.repartition(npartitions=n_parts)
     else:


### PR DESCRIPTION
`all_meta_df` creation is broken as of two weeks ago because of a `dask` update (`from_delayed` throws an error when the input is the empty list `[]`). This breaks basic functionality because `diy` assumes `create_graph` has `include_meta=False` in the input and output, but `create_graph` only works when `include_meta=True`.

I moved the `all_meta_df` creation a few lines down, after an `include_meta` check.

 See https://github.com/aertslab/arboreto/issues/38 for details.